### PR TITLE
save json files for pre-existing predictions

### DIFF
--- a/inference_engine/core/common/types.py
+++ b/inference_engine/core/common/types.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 
 class Sample(BaseModel):
@@ -24,12 +24,12 @@ class BatchLLMPrediction(BaseModel):
 
 class LLMOutput(Sample):
     llm_prediction: str
-    ntokens: int
-    proctime: float
+    ntokens: Optional[int]
+    proctime: Optional[float]
 
     @classmethod
     def from_sample(
-        cls, sample: Sample, llm_prediction: str, ntokens: int, proctime: float
+        cls, sample: Sample, llm_prediction: str, ntokens: Optional[int], proctime: Optional[float]
     ) -> "LLMOutput":
         return cls(
             video_path=sample.video_path,


### PR DESCRIPTION
- if qa.json file, if an entry has key llm_predictions with pre-computed predictions(List[str], same length as entry["conversations"]), it will be written into json file so that inference step can be skipped.
- in this case ntokens and proctime will be nulls (unless they are present in qa.json)
- entry["id"] must be present, because entry["video"] is a potentially nested path, which is not good to use for a file name. Also, extension might not be 4 chars. For youtube videos id will be "<youtube_id>_<segment_num>".